### PR TITLE
feat: parallelize local summary generation

### DIFF
--- a/src/core/summary_old.ts
+++ b/src/core/summary_old.ts
@@ -60,7 +60,7 @@ export async function getSummary(content: string[]) {
     const openAIApiKey = await getOpenAiApiKey();
     model = new ChatOpenAI({
       modelName: "gpt-4o", // Use a stronger model if possible
-      openAIApiKey,
+      openAIApiKey: openAIApiKey ?? undefined,
       temperature: 0.2,
       timeout: 120_000,
     });


### PR DESCRIPTION
## Summary
- generate Ollama summary chunk requests in parallel for faster local processing
- fix type handling for optional OpenAI API key

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run ts`


------
https://chatgpt.com/codex/tasks/task_e_68a63eb7877c83288d07fd4b5db47194