### PR TITLE
fix: keep settings inputs focused

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -25,6 +25,8 @@ export default function SettingsPage() {
 
   const updateSettings = async (patch: Partial<LLMProviderSettings>) => {
     if (!providerSettings) return;
+    const optimistic = { ...providerSettings, ...patch };
+    setProviderSettings(optimistic);
     setSavingProvider(true);
     const merged = await setLLMProviderSettings(patch).catch(console.error);
     if (merged) setProviderSettings(merged);
@@ -102,7 +104,6 @@ export default function SettingsPage() {
                     value={providerSettings.ollamaModel || ""}
                     placeholder="llama3.1"
                     onChange={(e) => updateSettings({ ollamaModel: e.target.value })}
-                    disabled={savingProvider}
                   />
                 </div>
                 <div>
@@ -112,7 +113,6 @@ export default function SettingsPage() {
                     value={providerSettings.ollamaBaseUrl || ""}
                     placeholder="http://localhost:11434"
                     onChange={(e) => updateSettings({ ollamaBaseUrl: e.target.value })}
-                    disabled={savingProvider}
                   />
                 </div>
               </div>
@@ -188,7 +188,6 @@ export default function SettingsPage() {
                     value={providerSettings.transcriptionModel || ""}
                     placeholder="whisper-1"
                     onChange={(e) => updateSettings({ transcriptionModel: e.target.value })}
-                    disabled={savingProvider}
                   />
                 </div>
                 <div className="md:col-span-2">
@@ -198,7 +197,6 @@ export default function SettingsPage() {
                     value={providerSettings.transcriptionBaseUrl || ""}
                     placeholder="http://localhost:8080"
                     onChange={(e) => updateSettings({ transcriptionBaseUrl: e.target.value })}
-                    disabled={savingProvider}
                   />
                 </div>
               </div>

--- a/src/core/summary_old.ts
+++ b/src/core/summary_old.ts
@@ -60,7 +60,7 @@ export async function getSummary(content: string[]) {
     const openAIApiKey = await getOpenAiApiKey();
     model = new ChatOpenAI({
       modelName: "gpt-4o", // Use a stronger model if possible
-      openAIApiKey,
+      openAIApiKey: openAIApiKey ?? undefined,
       temperature: 0.2,
       timeout: 120_000,
     });


### PR DESCRIPTION
## Summary
- avoid disabling text inputs in settings and update state optimistically
- handle missing OpenAI API key in legacy summary logic

## Testing
- `npm test` (fails: Missing script)
- `npm run ts`


------
https://chatgpt.com/codex/tasks/task_e_68a6669285288328844638b572974d7e