### PR TITLE
feat: allow deleting transcripts

### DIFF
--- a/src/components/ExplorePage.tsx
+++ b/src/components/ExplorePage.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import classNames from "clsx";
-import { Loader2, IndentIcon } from "lucide-react";
+import { Loader2, IndentIcon, Trash2Icon } from "lucide-react";
 import Markdown from "react-markdown";
 
 import { getSummary } from "../core/summary";
-import { DBContent, DBRecord, dbContents, dbRecords } from "../core/db";
+import { DBContent, DBRecord, dbContents, dbRecords, deleteRecord } from "../core/db";
 
 import {
   Card,
@@ -89,6 +89,13 @@ export default function ExplorePage({ recordId }: { recordId: string }) {
     }
   }, [generatingSummary]);
 
+  const handleDelete = useCallback(async () => {
+    if (!record) return;
+    if (!confirm("Delete this transcript?")) return;
+    await deleteRecord(record.id);
+    window.close();
+  }, [record]);
+
   if (fatalError) {
     return <FatalError error={fatalError} />;
   }
@@ -105,12 +112,20 @@ export default function ExplorePage({ recordId }: { recordId: string }) {
       <Header
         tab={tab}
         toolbar={
-          <div className="flex flex-col items-end justify-between">
-            <Badge variant="outline" className="rounded-sm">
-              {getPrettyDuration(createdAt, durationEndDate)}
-            </Badge>
-            <span className="mt-1 text-xs leading-none text-muted-foreground whitespace-nowrap">
-              <PrettyDate date={createdAt} />
+          <div className="flex items-center space-x-2">
+            <div className="flex flex-col items-end justify-between">
+              <Badge variant="outline" className="rounded-sm">
+                {getPrettyDuration(createdAt, durationEndDate)}
+              </Badge>
+              <span className="mt-1 text-xs leading-none text-muted-foreground whitespace-nowrap">
+                <PrettyDate date={createdAt} />
+              </span>
+            </div>
+            <span
+              className="cursor-pointer text-muted-foreground hover:text-destructive"
+              onClick={handleDelete}
+            >
+              <Trash2Icon className="w-5 h-5" />
             </span>
           </div>
         }

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,9 +1,9 @@
 import { memo, useEffect, useRef, useState } from "react";
 import classNames from "clsx";
 import { useLiveQuery } from "dexie-react-hooks";
-import { ChevronRightIcon, ScrollTextIcon } from "lucide-react";
+import { ChevronRightIcon, ScrollTextIcon, Trash2Icon } from "lucide-react";
 
-import { DBRecord, fetchRecords } from "../core/db";
+import { DBRecord, fetchRecords, deleteRecord } from "../core/db";
 import { buildMainURL } from "../config/extUrl";
 
 import TabAvatar from "./TabAvatar";
@@ -30,6 +30,12 @@ const HistoryItem = memo(
         url: buildMainURL(`/explore/${id}`),
         active: true,
       });
+    };
+
+    const handleDelete = async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!confirm("Delete this transcript?")) return;
+      await deleteRecord(id);
     };
 
     return (
@@ -91,18 +97,23 @@ const HistoryItem = memo(
               </div>
             </div>
 
-            <div>
-              <ChevronRightIcon
-                className={classNames(
-                  "text-muted-foreground",
-                  "w-6 h-auto",
-                  "absolute right-2.5 top-1/2 -translate-y-1/2",
-                  "transition",
-                  "group-hover:translate-x-0 group-hover:opacity-100",
-                  "-translate-x-1.5 opacity-0"
-                )}
-              />
-            </div>
+            <span
+              className={classNames(
+                "absolute right-2.5 top-1/2 -translate-y-1/2",
+                "flex items-center space-x-2",
+                "transition",
+                "group-hover:translate-x-0 group-hover:opacity-100",
+                "-translate-x-1.5 opacity-0"
+              )}
+            >
+              <span
+                className="cursor-pointer text-muted-foreground hover:text-destructive"
+                onClick={handleDelete}
+              >
+                <Trash2Icon className="w-4 h-4" />
+              </span>
+              <ChevronRightIcon className="text-muted-foreground w-6 h-auto" />
+            </span>
           </div>
         </button>
 

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -31,3 +31,7 @@ export const dbContents = db.table<DBContent>("contents");
 export async function fetchRecords(limit: number) {
   return dbRecords.orderBy("createdAt").reverse().limit(limit).toArray();
 }
+
+export async function deleteRecord(id: string) {
+  await Promise.all([dbRecords.delete(id), dbContents.delete(id)]);
+}


### PR DESCRIPTION
## Summary
- add DB helper to remove transcript and content records
- enable deleting transcripts from popup history list
- add delete action to transcript detail view
- ensure delete handler hook is registered on all renders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run ts`


------
https://chatgpt.com/codex/tasks/task_e_68a66e447a788328898b1f9a9bb05f31